### PR TITLE
#4: Change temp_dir default value to the system temporary directory

### DIFF
--- a/src/config/pdf.php
+++ b/src/config/pdf.php
@@ -22,7 +22,7 @@ return [
     'custom_font_dir'         => '',
     'custom_font_data'        => [],
     'auto_language_detection' => false,
-    'temp_dir'                => '',
+    'temp_dir'                => rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR),
     'pdfa'                    => false,
     'pdfaauto'                => false,
 ];


### PR DESCRIPTION
Before: `'temp_dir' => ''`, after: `'temp_dir' => 'rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)'`. That's all.