### PR TITLE
Add support for Laravel Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,15 @@
     },
     "autoload": {
         "psr-4": {"Meneses\\LaravelMpdf\\": "src/LaravelMpdf"}
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Meneses\\LaravelMpdf\\LaravelMpdfServiceProvider"
+            ],
+            "aliases": {
+                "PDF": "Meneses\\LaravelMpdf\\Facades\\LaravelMpdf"
+            }
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ To start using Laravel, add the Service Provider and the Facade to your `config/
 ]
 ```
 
+> Note: This package supports auto-discovery features of Laravel 5.5+, You only need to manually add the service provider and alias if working on Laravel version lower then 5.5
+
 ## Basic Usage
 
 To use Laravel Mpdf add something like this to one of your controllers. You can pass data to a view in `/resources/views`.


### PR DESCRIPTION
Added the support for Laravel 5.5+ autoloading capability of providers and aliases.

Updated the readme file to show a new note about the support.

Should make the installation a little easier.