### PR TITLE
Add ability to chunk big HTMLs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,39 @@ $pdf->getMpdf()->AddPage(...);
 
 ```
 
+## Chunk HTML
+
+For big HTML you might get `Uncaught Mpdf\MpdfException: The HTML code size is larger than pcre.backtrack_limit xxx` error, or you might just get [empty or blank result](https://mpdf.github.io/troubleshooting/known-issues.html#blank-pages-or-some-sections-missing). In these situations you can use chunk methods while you added a separator to your HTML:
+
+```php
+//....
+use PDF;
+class ReportController extends Controller {
+	public function generate_pdf() 
+	{
+		$data = [
+			'foo' => 'bar'
+		];
+		$pdf = PDF::chunkLoadView('<html-separator/>', 'pdf.document', $data);
+		return $pdf->stream('document.pdf');
+	}
+}
+```
+```html
+<div>
+    <h1>Hello World</h1>
+    <table>
+        <tr><td></td></tr>
+    </table>
+    <html-separator/>
+    <table>
+        <tr><td></td></tr>
+    </table>
+    <html-separator/>
+</div>
+```
+
+
 ## License
 
 Laravel Mpdf is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)

--- a/src/LaravelMpdf/Facades/LaravelMpdf.php
+++ b/src/LaravelMpdf/Facades/LaravelMpdf.php
@@ -3,7 +3,19 @@
 namespace Meneses\LaravelMpdf\Facades;
 
 use Illuminate\Support\Facades\Facade as BaseFacade;
+use Meneses\LaravelMpdf\LaravelMpdf as Pdf;
 
+/**
+ * Class LaravelMpdf
+ * @package Meneses\LaravelMpdf\Facades
+ *
+ * @method Pdf loadHTML(string $html, ?array $config = [])
+ * @method Pdf loadFile(string $file, ?array $config = [])
+ * @method Pdf loadView(string $view, ?array $data = [], ?array $mergeData = [], ?array $config = [])
+ * @method Pdf chunkLoadHTML(string $separator, string $html, ?array $config = [])
+ * @method Pdf chunkLoadFile(string $separator, string $file, ?array $config = [])
+ * @method Pdf chunkLoadView(string $separator, string $view, ?array $data = [], ?array $mergeData = [], ?array $config = [])
+ */
 class LaravelMpdf extends BaseFacade {
 
 	/**

--- a/src/LaravelMpdf/LaravelMpdf.php
+++ b/src/LaravelMpdf/LaravelMpdf.php
@@ -60,8 +60,6 @@ class LaravelMpdf {
 		$this->mpdf->showWatermarkText  = $this->getConfig('show_watermark');
 		$this->mpdf->watermark_font     = $this->getConfig('watermark_font');
 		$this->mpdf->watermarkTextAlpha = $this->getConfig('watermark_text_alpha');
-
-		$this->mpdf->WriteHTML($html);
 	}
 
 	protected function getConfig($key) {

--- a/src/LaravelMpdf/LaravelMpdf.php
+++ b/src/LaravelMpdf/LaravelMpdf.php
@@ -16,7 +16,7 @@ class LaravelMpdf {
 	protected $mpdf;
 	protected $config = [];
 
-	public function __construct($html = '', $config = [])
+	public function __construct($config = [])
 	{
 		$this->config = $config;
 

--- a/src/LaravelMpdf/LaravelMpdfWrapper.php
+++ b/src/LaravelMpdf/LaravelMpdfWrapper.php
@@ -4,9 +4,19 @@ namespace Meneses\LaravelMpdf;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\View;
+use Meneses\LaravelMpdf\LaravelMpdf as Pdf;
 
-class LaravelMpdfWrapper {
-
+class LaravelMpdfWrapper 
+{
+    /**
+     * @param array $config
+     * @return LaravelMpdf
+     */
+    public function getPdf($config = [])
+    {
+        return new LaravelMpdf($config);
+    }
+    
 	/**
 	 * Load a HTML string
 	 *
@@ -15,8 +25,30 @@ class LaravelMpdfWrapper {
 	 */
 	public function loadHTML($html, $config = [])
 	{
-		return new LaravelMpdf($html, $config);
+	    $pdf = $this->getPdf($config);
+	    $pdf->getMpdf()->WriteHTML($html);
+	    
+	    return $pdf;
 	}
+
+    /**
+     * Chunk a HTML with given word and load string
+     *
+     * @param string $separator 
+     * @param string $html
+     * @return Pdf
+     */
+    public function chunkLoadHTML($separator, $html, $config = [])
+    {
+        $pdf = $this->getPdf($config);
+        
+        $chunks = explode($separator, $html);
+        foreach($chunks as $chunk) {
+            $pdf->getMpdf()->WriteHTML($chunk);
+        }
+        
+        return $pdf;
+    }
 
 	/**
 	 * Load a HTML file
@@ -26,8 +58,20 @@ class LaravelMpdfWrapper {
 	 */
 	public function loadFile($file, $config = [])
 	{
-		return new LaravelMpdf(File::get($file), $config);
+	    return $this->loadHTML(File::get($file), $config);
 	}
+
+    /**
+     * Chunk a HTML file with given word and load HTML
+     *
+     * @param string $separator
+     * @param string $file
+     * @return Pdf
+     */
+	public function chunkLoadFile($separator, $file, $config = [])
+    {
+        return $this->chunkLoadHTML($separator, File::get($file), $config);
+    }
 
 	/**
 	 * Load a View and convert to HTML
@@ -39,7 +83,20 @@ class LaravelMpdfWrapper {
 	 */
 	public function loadView($view, $data = [], $mergeData = [], $config = [])
 	{
-		return new LaravelMpdf(View::make($view, $data, $mergeData)->render(), $config);
+	    return $this->loadHTML(View::make($view, $data, $mergeData)->render(), $config);
 	}
 
+    /**
+     * Chunk a View with given word and load HTML
+     *
+     * @param string $separator
+     * @param string $view
+     * @param array $data
+     * @param array $mergeData
+     * @return Pdf
+     */
+    public function chunkLoadView($separator, $view, $data = [], $mergeData = [], $config = [])
+    {
+        return $this->chunkLoadHTML($separator, View::make($view, $data, $mergeData)->render(), $config);
+    }
 }


### PR DESCRIPTION
When HTML is big (depends on backtrack_limit) mpdf will [throw an error](https://mpdf.github.io/troubleshooting/known-issues.html#blank-pages-or-some-sections-missing) or result will be blank. This PR will add 3 methods to chunk HTML.