### PR TITLE
Set default temp_dir to laravel app storage path

### DIFF
--- a/config/pdf.php
+++ b/config/pdf.php
@@ -28,7 +28,7 @@ return [
     'custom_font_dir'          => '',
     'custom_font_data'         => [],
     'auto_language_detection'  => false,
-    'temp_dir'                 => rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR),
+    'temp_dir'                 => storage_path('app'),
     'pdfa'                     => false,
     'pdfaauto'                 => false,
     'use_active_forms'         => false,


### PR DESCRIPTION
Fix to issue #93
I am suggesting to change the default `temp_dir` config into Laravel `storage_path`, so that when there is a case the php doesn't have the permission to write into system temp dir (especially when the app run in production/linux os) it should be ok.