### PR TITLE
allow configuration for SetDocTemplate()

### DIFF
--- a/src/LaravelMpdf.php
+++ b/src/LaravelMpdf.php
@@ -79,6 +79,9 @@ class LaravelMpdf
 
         // use_dictionary_lbr
         $this->mpdf->useDictionaryLBR = $this->getConfig('use_dictionary_lbr');
+
+        // use templates
+        $this->mpdf->SetDocTemplate($this->getConfig('doc_template_file'), $this->getConfig('doc_template_continue'), $this->getConfig('doc_template_continue2pages'));
     }
 
     protected function getConfig($key)


### PR DESCRIPTION
This will allow us to set a Document Template based on [SetDocTemplate()](https://mpdf.github.io/reference/mpdf-functions/setdoctemplate.html)

also Fixes #136 

Example:
```php
$pdf = MPDF::loadView('report', config: ['doc_template_file' => 'template.pdf','doc_template_continue' => true]);
```