### PR TITLE
Fixed return type of getMpdf method

### DIFF
--- a/src/LaravelMpdf.php
+++ b/src/LaravelMpdf.php
@@ -88,7 +88,7 @@ class LaravelMpdf
 
     /**
      * Get instance mpdf
-     * @return static
+     * @return \Mpdf\Mpdf
      */
     public function getMpdf()
     {


### PR DESCRIPTION
Return type of getMpdf method must be Mpdf\Mpdf, currently static is returned in method comments.